### PR TITLE
Make wandb optional

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -47,6 +47,7 @@ class TrainingConfig:
     random_state: int = 42
     device: torch.device = field(default_factory=lambda: get_device())
     dataset_root_dir: str = DATASET_BASE_DIR
+    disable_wandb: bool = False
     hyperparameters: Hyperparameters = field(default_factory=Hyperparameters)
 
     def __post_init__(self):

--- a/src/utils/wandb.py
+++ b/src/utils/wandb.py
@@ -1,6 +1,7 @@
 from dotenv import load_dotenv
 import os
 import wandb
+from contextlib import nullcontext
 
 from src.utils.config import TrainingConfig
 
@@ -42,3 +43,20 @@ def verify_wandb_config(wb_config: dict, training_config: TrainingConfig):
     match_architecture = architecture == wb_config.get("architecture", None)
 
     return match_hyperparameters and match_dataset and match_architecture
+
+
+def wandb_init(config: dict, disable_wandb: bool = False, **kwargs):
+    """
+    Initialize wandb if the disable_wandb flag is not set
+
+    Args:
+    - config (dict): the dictionary containing the training configuration
+    - additional_params (dict): additional parameters to log to wandb
+
+    Returns:
+    - wandb.init or null context manager
+    """
+    if not disable_wandb:
+        return wandb.init(config=config, **kwargs)
+    else:
+        return nullcontext()


### PR DESCRIPTION
I added wandb to track our experiments in the cloud, however, we shouldn't always use wandb!

This PR adds `disable_wandb` flag to our `train_segmentation.py` script to fix this issue.